### PR TITLE
Wheels arent enabled by default

### DIFF
--- a/minibot/bot.py
+++ b/minibot/bot.py
@@ -44,6 +44,10 @@ class Bot():
                       PWM(self.actuators["right"]["pinPWM"]))
         self.stop()
 
+        #Starts wheels
+        wheelEnabler = DigitalOutput(config["wheelEnablerPin"])
+        wheelEnabler.set_high()
+
         for sensor in config["sensors"]:
             name = sensor["name"]
             pin = sensor["pin"]

--- a/minibot/bot.py
+++ b/minibot/bot.py
@@ -42,6 +42,7 @@ class Bot():
                       PWM(self.actuators["left"]["pinPWM"]),
                       DigitalOutput(self.actuators["right"]["pinHighLow"]),
                       PWM(self.actuators["right"]["pinPWM"]))
+        self.stop()
 
         for sensor in config["sensors"]:
             name = sensor["name"]

--- a/minibot/configs/config.json
+++ b/minibot/configs/config.json
@@ -5,6 +5,7 @@
   "discoverable": true,
   "acceptTcp": true,
   "acceptXbox": true,
+  "wheelEnablerPin": 17,
   "actuators": [
     {
        "name" : "leftMotor",


### PR DESCRIPTION
Solution: 
Moved pin from power to pin 17. This turns wheels off by default. The pin is then set high on start up. 

No more bots going crazy on revival. NO more bot suicide. 